### PR TITLE
force a list for loop

### DIFF
--- a/playbooks/example-playbook.yml
+++ b/playbooks/example-playbook.yml
@@ -63,7 +63,7 @@
     - name: Check if resources naming matches the naming guideline (only alphanumerics)
       debug:
         msg: "{{ item | anatomicjc.passbolt.check_naming(passbolt_check_naming_only_alphanumerics) }}"
-      loop: "{{ lookup(passbolt_inventory) }}"
+      loop: "{{ lookup(passbolt_inventory) | list }}"
       ignore_errors: yes
     - name: Get a single resource and check if it matches the naming guideline (alphanumeric with spaces)
       debug:


### PR DESCRIPTION
Fixing issue https://github.com/passbolt/lab-passbolt-ansible-poc/issues/3

Error Before this MR :
```
TASK [Check if resources naming matches the naming guideline (only alphanumerics)] ***************************************
fatal: [plantuml]: FAILED! => {"msg": "Invalid data passed to 'loop', it requires a list, got this instead: {'id': '9fbbff37-6fa5-4ec1-b99a-de35bcfc7313', 'name': 'Test Password', 'username': 'test', 'uri': 'http://127.0.0.1', 'description': None, 'deleted': False, 'created': '2023-09-21T08:20:40+00:00', 'modified': '2023-09-21T08:20:40+00:00', 'created_by': '98b19fd5-1bf5-4009-8d37-74c6f1f753fc', 'modified_by': '98b19fd5-1bf5-4009-8d37-74c6f1f753fc', 'resource_type_id': 'a28a04cd-6f53-518a-967c-9963bf9cec51', 'folder_parent_id': None, 'personal': True}. Hint: If you passed a list/dict of just one element, try adding wantlist=True to your lookup invocation or use q/query instead of lookup."}
```